### PR TITLE
[JAVA11] update JAXB dependencies

### DIFF
--- a/org.eclipselabs.collage.colourpicker/META-INF/MANIFEST.MF
+++ b/org.eclipselabs.collage.colourpicker/META-INF/MANIFEST.MF
@@ -14,3 +14,6 @@ Export-Package: org.eclipselabs.collage.colourpicker,
  org.eclipselabs.collage.colourpicker.model,
  org.eclipselabs.collage.colourpicker.parts.tree,
  org.eclipselabs.collage.colourpicker.tools
+Import-Package: javax.xml.bind;version="2.3.3",
+ javax.xml.bind.annotation;version="2.3.3",
+ javax.xml.bind.annotation.adapters;version="2.3.3"

--- a/org.eclipselabs.collage.draw/META-INF/MANIFEST.MF
+++ b/org.eclipselabs.collage.draw/META-INF/MANIFEST.MF
@@ -3,6 +3,9 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Draw plugin for Collage
 Bundle-SymbolicName: org.eclipselabs.collage.draw;singleton:=true
 Bundle-Version: 0.1.1.qualifier
+Import-Package: javax.xml.bind;version="2.3.3",
+ javax.xml.bind.annotation;version="2.3.3",
+ javax.xml.bind.annotation.adapters;version="2.3.3"
 Bundle-Vendor: Alex Bradley
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Require-Bundle: org.eclipselabs.collage;bundle-version="0.1.0",

--- a/org.eclipselabs.collage.text/META-INF/MANIFEST.MF
+++ b/org.eclipselabs.collage.text/META-INF/MANIFEST.MF
@@ -3,6 +3,8 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Collage text box extension
 Bundle-SymbolicName: org.eclipselabs.collage.text;singleton:=true
 Bundle-Version: 0.1.1.qualifier
+Import-Package: javax.xml.bind;version="2.3.3",
+ javax.xml.bind.annotation;version="2.3.3"
 Bundle-Vendor: Alex Bradley
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/org.eclipselabs.collage/META-INF/MANIFEST.MF
+++ b/org.eclipselabs.collage/META-INF/MANIFEST.MF
@@ -26,3 +26,6 @@ Export-Package: org.eclipselabs.collage,
  org.eclipselabs.collage.tools,
  org.eclipselabs.collage.ui,
  org.eclipselabs.collage.util
+Import-Package: javax.xml.bind;version="2.3.3",
+ javax.xml.bind.annotation;version="2.3.3",
+ javax.xml.bind.annotation.adapters;version="2.3.3"


### PR DESCRIPTION
Update dependencies for JAXB
https://docs.oracle.com/en/java/javase/20/migrate/removed-tools-and-components.html#GUID-460800EF-A523-4B10-B694-E3536AC419C1